### PR TITLE
Use workspace path from Github default env variables

### DIFF
--- a/src/create-envfile.py
+++ b/src/create-envfile.py
@@ -15,7 +15,9 @@ directory = str(os.environ.get("INPUT_DIRECTORY"))
 # .env is set by default
 file_name = str(os.environ.get("INPUT_FILE_NAME"))
 
-path = "/github/workspace"
+path = str(os.environ.get("INPUT_GITHUB_WORKSPACE"))
+if path == "":
+    raise Exception("Could not get the GITHUB_WORKSPACE environment variable.") 
 
 with open(os.path.join(path, directory, file_name), "w") as text_file:
     text_file.write(out_file)


### PR DESCRIPTION
This closes #7. The `GITHUB_WORKSPACE` environment variable is provided to each Action, and should be used to know where the workspace is instead of hardcoding it.

I still have to test this to look at any potential ramifications from how the workflow is currently working for other repos.