### PR TITLE
Added input to toggle failing on empty env key

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -170,3 +170,48 @@ jobs:
       uses: ./
       with:
         envkey_SECRET_KEY: ${{ secrets.NON_EXISTENT_SECRET }}
+
+  # Test empty envkeys
+  should-fail-test-empty-envkey:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Create folder
+      run: |
+        mkdir -p subdir
+
+    - name: Make envfile
+      uses: ./
+      with:
+        envkey_SECRET_KEY: ""
+        fail_on_empty: true
+
+  test-empty-envkey-default-option:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Create folder
+      run: |
+        mkdir -p subdir
+
+    - name: Make envfile
+      uses: ./
+      with:
+        envkey_SECRET_KEY: ""
+
+    - name: Verify envfile
+      run: |
+        TEST=$(cat <<-END
+          SECRET_KEY=
+        END
+        )
+        if [ "$TEST" != "$(cat .env)" ]
+        then
+            echo "ERR"
+        fi

--- a/action.yml
+++ b/action.yml
@@ -1,16 +1,19 @@
-  name: 'Create .env file'
-  description: 'Github Action to create a .env file with Github Secrets'
-  author: 'Forest Anderson'
-  branding:
-    icon: 'briefcase'
-    color: 'gray-dark'
-  inputs:
-    file_name:
-      description: 'The filename for the envfile'
-      default: '.env'
-    directory:
-      description: 'The directory to put the envfile in'
-      default: ''
-  runs:
-    using: 'docker'
-    image: 'Dockerfile'
+name: "Create .env file"
+description: "Github Action to create a .env file with Github Secrets"
+author: "Forest Anderson"
+branding:
+  icon: "briefcase"
+  color: "gray-dark"
+inputs:
+  file_name:
+    description: "The filename for the envfile"
+    default: ".env"
+  directory:
+    description: "The directory to put the envfile in"
+    default: ""
+  fail_on_empty:
+    description: "Fail if an env key is an empty string"
+    default: "false"
+runs:
+  using: "docker"
+  image: "Dockerfile"

--- a/src/create-envfile.py
+++ b/src/create-envfile.py
@@ -11,7 +11,7 @@ for key in sorted(env_keys):
         value = os.getenv(key, "")
 
         # If the key is empty, throw an error.
-        if value == "":
+        if value == "" and os.getenv("INPUT_FAIL_ON_EMPTY", "false") == "true":
             raise Exception(f"Empty env key found: {key}")
 
         out_file += "{}={}\n".format(key.split("INPUT_ENVKEY_")[1], value)


### PR DESCRIPTION
This closes #42 and should remove the backwards incompatibility by default, instead adding it behind an Action toggle.