### PR TITLE
Remove /github/workspace default for GITHUB_WORKSPACE

### DIFF
--- a/src/create-envfile.py
+++ b/src/create-envfile.py
@@ -23,7 +23,7 @@ directory = str(os.getenv("INPUT_DIRECTORY", ""))
 # .env is set by default
 file_name = str(os.getenv("INPUT_FILE_NAME", ".env"))
 
-path = str(os.getenv("GITHUB_WORKSPACE", "/github/workspace"))
+path = str(os.getenv("GITHUB_WORKSPACE"))
 
 # This should resolve https://github.com/SpicyPizza/create-envfile/issues/27
 if path in ["", "None"]:


### PR DESCRIPTION
Setting this as a default overrides the default that github sets it as ``/home/runner/work/REPO_NAME/REPO_NAME``. Majority use cases would like this file to be injected inside of root or ``src``. Addresses https://github.com/SpicyPizza/create-envfile/issues/45 .