### PR TITLE
fix: Node.js 16 deprecation warning

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -23,10 +23,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set Node.js 16.x
-        uses: actions/setup-node@v3.8.1
+      - name: Set Node.js 20.x
+        uses: actions/setup-node@v4
         with:
-          node-version: 16.x
+          node-version: 20.x
 
       - name: Install dependencies
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -106,6 +106,3 @@ lib/**/*
 .yarn/sdks
 .yarn/versions
 .yarn/install-state.gz
-
-# IDE
-.idea

--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,6 @@ lib/**/*
 .yarn/sdks
 .yarn/versions
 .yarn/install-state.gz
+
+# IDE
+.idea

--- a/action.yml
+++ b/action.yml
@@ -18,5 +18,5 @@ inputs:
     description: 'Sort the keys alphabetically'
     default: 'false'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@actions/core": "^1.10.0"
   },
   "devDependencies": {
-    "@tsconfig/node16": "^16.1.0",
+    "@tsconfig/node20": "^20.1.2",
     "@types/node": "^20.8.7",
     "@typescript-eslint/parser": "^5.59.2",
     "@vercel/ncc": "^0.36.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node16/tsconfig.json",
+  "extends": "@tsconfig/node20/tsconfig.json",
   "compilerOptions": {
     "outDir": "./lib",                        /* Redirect output structure to the directory. */
     "rootDir": "./src",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */

--- a/yarn.lock
+++ b/yarn.lock
@@ -178,10 +178,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tsconfig/node16@npm:^16.1.0":
-  version: 16.1.0
-  resolution: "@tsconfig/node16@npm:16.1.0"
-  checksum: a0a176492e3802a5340eda1e61eabc8d4767e46496bc080ce9c381993ce8c5fb3df8f65267c3a9af4335bc00a85028845f795ea27545f63d62b93ab6675cf8fa
+"@tsconfig/node20@npm:^20.1.2":
+  version: 20.1.2
+  resolution: "@tsconfig/node20@npm:20.1.2"
+  checksum: fc126e15f0817bd328c15bd6be7972f01ef4d55ceb493c7a83ccb9dd545e39f218711f330e3df4072b116b11180c07943da2b2bfcd7adc58414cb586db52a4c8
   languageName: node
   linkType: hard
 
@@ -722,7 +722,7 @@ __metadata:
   resolution: "create-envfile@workspace:."
   dependencies:
     "@actions/core": ^1.10.0
-    "@tsconfig/node16": ^16.1.0
+    "@tsconfig/node20": ^20.1.2
     "@types/node": ^20.8.7
     "@typescript-eslint/parser": ^5.59.2
     "@vercel/ncc": ^0.36.1


### PR DESCRIPTION
I have no experience with GitHub action development. I just went through the code and updated all node version references to 20 and ran the `npm run all` script. Let me know if I need to change anything.